### PR TITLE
Use empty tree as base revision if HEAD^ invalid

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,11 @@ fi
 
 repository=$(mktemp)
 if git rev-parse --git-dir 2> "$repository"; then
+  if ! git rev-parse --quiet --verify "$base" > /dev/null; then
+    # invalid base revision -- use the "empty tree" instead
+    base="$(echo -n | git hash-object -t tree --stdin)"
+  fi
+
   set -x
   git rev-parse "$base"
   git rev-parse "HEAD"


### PR DESCRIPTION
In certain instances (such as creating a repository from a template in
which existing history is collapsed), HEAD^ may not refer to a valid
revision because the initial commit has no parent. Consequently, the
action fails with the following error message:

    fatal: ambiguous argument 'HEAD^': unknown revision or path not
            in the working tree.

This change verifies that the base revision is valid before attempting
to use the reference in the invocation of `git diff`. If HEAD^ does
not exist, then the revision of the empty tree is used as the base
instead -- i.e., an empty tree represents the (hypothetical) parent of
the current commit.

Closes #2